### PR TITLE
Remove trailing '/' in hostname

### DIFF
--- a/safaribooks/spiders/safaribooks.py
+++ b/safaribooks/spiders/safaribooks.py
@@ -50,8 +50,8 @@ class SafariBooksSpider(scrapy.spiders.Spider):
     toc_url = 'https://www.safaribooksonline.com/nest/epub/toc/?book_id='
     name = 'SafariBooks'
     # allowed_domains = []
-    start_urls = ['https://www.safaribooksonline.com/']
-    host = 'https://www.safaribooksonline.com/'
+    start_urls = ['https://www.safaribooksonline.com']
+    host = 'https://www.safaribooksonline.com'
 
     def __init__(
         self,


### PR DESCRIPTION
otherwise scrapy does silly things like

```
2018-11-16 05:02:09 [scrapy.core.engine] DEBUG: Crawled (404) <GET https://www.safaribooksonline.com//api/v1/book/<bookid>/chapter/ch10s03.html> (referer: https://www.safaribooksonline.com/nest/epub/toc/?book_id=<bookid>)
```