### PR TITLE
fix: Fixes https://github.com/ViciousPotato/safaribooks/issues/54

### DIFF
--- a/safaribooks/spiders/safaribooks.py
+++ b/safaribooks/spiders/safaribooks.py
@@ -43,7 +43,7 @@ class SafariBooksSpider(scrapy.spiders.Spider):
     name = 'SafariBooks'
     # allowed_domains = []
     start_urls = ['https://www.safaribooksonline.com/']
-    host = 'https://www.safaribooksonline.com/'
+    host = 'https://www.safaribooksonline.com'
 
     def __init__(
         self,
@@ -81,7 +81,7 @@ class SafariBooksSpider(scrapy.spiders.Spider):
 
         cookies = dict(x.strip().split('=') for x in self.cookie.split(';')) if self.cookie is not None else {}
 
-        return scrapy.Request(url=self.host + 'home', 
+        return scrapy.Request(url=self.host + '/home', 
             callback=self.after_login,
             cookies=cookies,
             headers={


### PR DESCRIPTION
- safaribooksonline API now returns URL with '/' prefixed to it
- This adds to the presence of '//' in safaribooksonline URL 
- For URL with '//' safaribooksonline provides a 404 response