### PR TITLE
Updated to use new URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,5 +100,8 @@ ENV/
 # mypy
 .mypy_cache/
 
+# Mac Stuff
+.DS_Store
+
 # Converted files
 /converted/

--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ WARNING: use at your own risk.
 1. If you want Kindle mobi output, download kindlegen from Amazon and put the binary somewhere in PATH.
 
    If you only need epub books this step can be skipped.
-   
+
 2. Clone the safaribooks repo, let's say to `safaribooks/` directory.
 
 3. Make sure you have Python 2 installed (Tested version Python 2.7) then run:
 
    `cd safaribooks`
-   
+
    `pip install .`
 
    safaribooks is the folder you checkout the code.
@@ -24,7 +24,7 @@ WARNING: use at your own risk.
 
   `safaribooks -u USER/EMAIL -p PASSWORD -b BOOK_ID download-epub`.
 
-   `BOOK_ID` is the id in url such as `9781617291920` in `https://www.safaribooksonline.com/library/view/real-world-machine-learning/9781617291920/kindle_split_011.html`.
+   `BOOK_ID` is the id in url such as `9781617291920` in `https://learning.oreilly.com/library/view/real-world-machine-learning/9781617291920/kindle_split_011.html`.
 
    An epub and a mobi file will be generated.
 
@@ -66,7 +66,7 @@ optional arguments:
                         Safari Books Online password
   -b BOOK_ID, --book-id BOOK_ID
                         Safari Books Online book ID
-  -c COOKIE, --cookie COOKIE 
+  -c COOKIE, --cookie COOKIE
                         Safari Books Online Cookie. This filed can be retrieved by
                         using Chrome and copying request as curl. Cookie input should
                         be included in ''.

--- a/safaribooks/spiders/safaribooks.py
+++ b/safaribooks/spiders/safaribooks.py
@@ -47,11 +47,11 @@ def decode(s):
         return s
 
 class SafariBooksSpider(scrapy.spiders.Spider):
-    toc_url = 'https://www.safaribooksonline.com/nest/epub/toc/?book_id='
+    toc_url = 'https://learning.oreilly.com/nest/epub/toc/?book_id='
     name = 'SafariBooks'
     # allowed_domains = []
-    start_urls = ['https://www.safaribooksonline.com/']
-    host = 'https://www.safaribooksonline.com/'
+    start_urls = ['https://learning.oreilly.com']
+    host = 'https://learning.oreilly.com'
 
     def __init__(
         self,
@@ -90,7 +90,7 @@ class SafariBooksSpider(scrapy.spiders.Spider):
         if self.cookie is not None:
             cookies = dict(x.strip().split('=') for x in self.cookie.split(';'))
 
-            return scrapy.Request(url=self.host + 'home', 
+            return scrapy.Request(url=self.host + 'home',
                 callback=self.after_login,
                 cookies=cookies,
                 headers={


### PR DESCRIPTION
Safari changed the URL to https://learning.oreilly.com/ in December 2018.  Updated to use new URL and tested.